### PR TITLE
chore: replace tail -1 with p6_filter_row_last

### DIFF
--- a/lib/util.sh
+++ b/lib/util.sh
@@ -63,7 +63,7 @@ p6_git_util_sha_short_get() {
 ######################################################################
 p6_git_util_dirty_get() {
 
-    local gstatus="$(p6_git_cli status 2>/dev/null | tail -1)"
+    local gstatus="$(p6_git_cli status 2>/dev/null | p6_filter_row_last 1)"
 
     p6_string_blank "$gstatus"
     local rc=$?


### PR DESCRIPTION
## Summary

- Replace raw `tail -1` with `p6_filter_row_last 1` in `lib/util.sh:66` for consistency with the p6common stdlib filter API

## Test plan

- [ ] `p6_git_util_dirty_get` continues to return the correct status

🤖 Generated with [Claude Code](https://claude.com/claude-code)