### PR TITLE
feat(util): add p6_git_util_has_remote helper function

### DIFF
--- a/lib/util.sh
+++ b/lib/util.sh
@@ -89,6 +89,25 @@ p6_git_util_inside_tree() {
 ######################################################################
 #<
 #
+# Function: p6_git_util_has_remote(remote)
+#
+#  Args:
+#	remote -
+#
+#>
+######################################################################
+p6_git_util_has_remote() {
+    local remote="$1"
+
+    p6_git_cli remote get-url "$remote" > /dev/null 2>&1
+    local rc=$?
+
+    p6_return_code_as_code "$rc"
+}
+
+######################################################################
+#<
+#
 # Function: p6_git_util_clobber()
 #
 #>


### PR DESCRIPTION
## What
Add `p6_git_util_has_remote` utility function to `lib/util.sh` that checks whether a named git remote exists for the current repository.

## Why
Provides a reusable helper to test for the existence of a git remote by name (e.g. `origin`, `upstream`), enabling callers to branch logic without relying on error output or subshell tricks.

## Test plan
- Manually invoke `p6_git_util_has_remote origin` in a repo with and without the named remote and verify it returns the correct exit code.
- No automated test suite changes required; existing CI linting covers shell syntax.

## Dependencies
None